### PR TITLE
Correctly escape paths with system calls

### DIFF
--- a/terminal_velocity/urwid_ui.py
+++ b/terminal_velocity/urwid_ui.py
@@ -5,6 +5,7 @@ Implemented using the console user interface library urwid.
 """
 import subprocess
 import shlex
+import pipes
 import logging
 logger = logging.getLogger(__name__)
 
@@ -322,16 +323,16 @@ class MainFrame(urwid.Frame):
 
         elif key in ["enter"]:
             if self.selected_note:
-                system(self.editor + " '" + self.selected_note.abspath + "'", self.loop)
+                system(self.editor + ' ' + pipes.quote(self.selected_note.abspath), self.loop)
             else:
                 if self.search_box.edit_text:
                     try:
                         note = self.notebook.add_new(self.search_box.edit_text)
-                        system(self.editor + " '" + note.abspath + "'", self.loop)
+                        system(self.editor + ' ' + pipes.quote(note.abspath), self.loop)
                     except notebook.NoteAlreadyExistsError:
                         # Try to open the existing note instead.
-                        system(self.editor + " '" + self.search_box.edit_text +
-                                self.notebook.extension + "'",
+                        system(self.editor + ' ' + pipes.quote(self.search_box.edit_text +
+                                self.notebook.extension),
                             self.loop)
                     except notebook.InvalidNoteTitleError:
                         # TODO: Display error message to user.


### PR DESCRIPTION
This correctly escapes the path in the system call for editor, no matter the file names