### PR TITLE
Python six

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/*
 terminal_velocity.egg-info/
 build
 build/*
+
+.tox
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  # - "3.5-dev"  # 3.5 development branch
+  - "3.6"
+  # - "3.6-dev"  # 3.6 development branch
+  # - "3.7-dev"  # 3.7 development branch
+
+install:
+  - pip install tox-travis
+
+script:
+  - tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,3 +121,19 @@ You can also setup different aliases (e.g. in your `~/.bashrc` or
     alias tv="/usr/local/bin/terminal_velocity"
     alias tvdev="/home/seanh/.virtualenvs/terminal_velocity/bin/python /home/seanh/Projects/terminal_velocity/bin/terminal_velocity"
 
+
+## Testing
+
+Automatic testing for all required python versions are performed using [pytest](https://docs.pytest.org/en/latest/) via [tox](https://tox.readthedocs.io/en/latest/).
+
+The `tox.ini` file defined which python versions will this package be tested on.
+To run the tests for all the defined python version, simply run
+
+    $ workon terminal_velocity
+    (terminal_velocity) $ pip install tox
+    (terminal_velocity) $ tox
+
+To run a single python version pass the `-e` flag. For example for python 3.6:
+
+    (terminal_velocity) $ tox -e py36
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Terminal Velocity
 
+Master branch:
+[![Build Status](https://travis-ci.org/jorgehatccrma/terminal_velocity.svg?branch=master)](https://travis-ci.org/jorgehatccrma/terminal_velocity)
+
+pythonSix branch:
+[![Build Status](https://travis-ci.org/jorgehatccrma/terminal_velocity.svg?branch=pythonSix)](https://travis-ci.org/jorgehatccrma/terminal_velocity)
+
+
 Terminal Velocity is a fast note-taking app for the UNIX terminal, that
 focuses on letting you create or find a note as quickly and easily as
 possible, then uses your `$EDITOR` to open and edit the note. It is

--- a/bin/terminal_velocity
+++ b/bin/terminal_velocity
@@ -2,7 +2,8 @@
 """A fast note-taking app for the UNIX terminal"""
 
 import argparse
-import ConfigParser
+# Python 2 and 3 (after ``pip install configparser``):
+from configparser import ConfigParser
 import os
 import logging
 import logging.handlers
@@ -22,7 +23,7 @@ def main():
 
     # Parse the config file.
     config_file = os.path.abspath(os.path.expanduser(args.config))
-    config = ConfigParser.SafeConfigParser()
+    config = ConfigParser()   # JH: not really sure what SafeConfigParser() was doing.
     config.read(config_file)
     defaults = dict(config.items('DEFAULT'))
 
@@ -96,7 +97,7 @@ the default default will be used"""
     args.exclude = exclude
 
     if args.print_config:
-        print args
+        print(args)
         sys.exit()
 
     logger = logging.getLogger("terminal_velocity")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# IMORTANT: KEEP THIS FILE AS IS
+# (maybe add lines, but don't change it substantially)
+#
+# see https://caremad.io/posts/2013/07/setup-vs-requirement/ for details
+
+--index-url https://pypi.python.org/simple
+
+# this allows to read dependencies from `setup.py` (`instal_requires`)
+-e .

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ setup(
     install_requires=[
         "urwid==1.1.1",
         "chardet==2.1.1",
+        "future==0.16.0",
+        "configparser==3.5.0",
         ],
     classifiers=[
         'Programming Language :: Python :: 2',

--- a/terminal_velocity/notebook.py
+++ b/terminal_velocity/notebook.py
@@ -52,6 +52,7 @@ This module provides a simple brute force full text search implementation.
 Other modules could provide better search functions that could be plugged in.
 
 """
+from builtins import str
 import logging
 logger = logging.getLogger(__name__)
 import os
@@ -64,8 +65,11 @@ def unicode_or_bust(raw_text):
     """Return the given raw text data decoded to unicode.
 
     If the text cannot be decoded, return None.
-
     """
+
+    if sys.version_info >= (3,0):
+        return raw_text
+
     encodings = ["utf-8"]
     for encoding in (sys.getfilesystemencoding(), sys.getdefaultencoding()):
         # I would use a set for this, but they don't maintain order.
@@ -75,7 +79,7 @@ def unicode_or_bust(raw_text):
     for encoding in encodings:
         if encoding:  # getfilesystemencoding() may return None
             try:
-                decoded = unicode(raw_text, encoding=encoding)
+                decoded = str(raw_text, encoding=encoding)
                 return decoded
             except UnicodeDecodeError:
                 pass
@@ -84,7 +88,7 @@ def unicode_or_bust(raw_text):
     encoding = chardet.detect(raw_text)["encoding"]
     if encoding and encoding not in encodings:
         try:
-            decoded = unicode(raw_text, encoding=encoding)
+            decoded = str(raw_text, encoding=encoding)
             logger.debug("File decoded with chardet, encoding was {0}".format(
                 encoding))
             return decoded
@@ -95,7 +99,7 @@ def unicode_or_bust(raw_text):
 
     # I've heard that decoding with cp1252 never fails, so try that last.
     try:
-        decoded = unicode(raw_text, encoding="cp1252")
+        decoded = str(raw_text, encoding="cp1252")
         logger.debug("File decoded with encoding cp1252")
         return decoded
     except UnicodeDecodeError:

--- a/terminal_velocity/urwid_ui.py
+++ b/terminal_velocity/urwid_ui.py
@@ -3,6 +3,7 @@
 Implemented using the console user interface library urwid.
 
 """
+import sys
 import subprocess
 import shlex
 import pipes
@@ -10,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import urwid
-import notebook
+from . import notebook
 
 
 palette = [
@@ -28,7 +29,9 @@ def system(cmd, loop):
     loop.screen.stop()
 
     cmd = u"{0}".format(cmd)
-    cmd = cmd.encode("utf-8")  # FIXME: Correct encoding?
+    # FIXME: write more idiomatic python 2 & 3 implementation?
+    if sys.version_info < (3,0):
+        cmd = cmd.encode("utf-8")  # FIXME: Correct encoding?
     safe_cmd = shlex.split(cmd)
 
     logger.debug("System command: {0}".format(safe_cmd))

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+data/tmp/

--- a/tests/data/notebook_01/note1.md
+++ b/tests/data/notebook_01/note1.md
@@ -1,0 +1,5 @@
+# Notes
+
+- on
+- multiple
+- topics

--- a/tests/data/notebook_01/note2.txt
+++ b/tests/data/notebook_01/note2.txt
@@ -1,0 +1,1 @@
+A TXT file

--- a/tests/data/notebook_01/note3.csv
+++ b/tests/data/notebook_01/note3.csv
@@ -1,0 +1,3 @@
+id, topic
+1, "science"
+4, "sports"

--- a/tests/notebook_test.py
+++ b/tests/notebook_test.py
@@ -1,0 +1,7 @@
+import pytest
+
+from terminal_velocity.notebook import *
+
+
+def test_fake():
+    assert True

--- a/tests/notebook_test.py
+++ b/tests/notebook_test.py
@@ -1,7 +1,43 @@
+import os
 import pytest
 
 from terminal_velocity.notebook import *
 
 
-def test_fake():
-    assert True
+def test_notebook_constructor():
+    """Create a notebook without raising an exception"""
+
+    notebook_path = 'tests/data/tmp/'
+    ext = '.md'
+    exts = ['.md', '.txt']
+
+    PlainTextNoteBook(notebook_path, extension=ext, extensions=exts)
+
+
+def test_notebook_existing():
+    """Notebook from existing folder"""
+
+    notebook_path = 'tests/data/notebook_01/'
+    ext = '.md'
+
+    exts = ['.md', '.txt']
+    assert len(
+        PlainTextNoteBook(notebook_path, extension=ext, extensions=exts)) == 2
+
+    exts.append('.csv')
+    assert len(
+        PlainTextNoteBook(notebook_path, extension=ext, extensions=exts)) == 3
+
+
+def test_notebook_search():
+    """Notebook's search functionality tests"""
+
+    notebook_path = 'tests/data/notebook_01/'
+    ext = '.md'
+    exts = ['.md', '.txt']
+
+    notebook = PlainTextNoteBook(notebook_path, extension=ext, extensions=exts)
+
+    assert len([n for n in notebook.search("note")]) == 2
+    assert len([n for n in notebook.search("note1")]) == 1
+    assert len([n for n in notebook.search("topics")]) == 1

--- a/tests/urwid_ui_test.py
+++ b/tests/urwid_ui_test.py
@@ -1,0 +1,8 @@
+import pytest
+
+from terminal_velocity.urwid_ui import *
+
+
+def test_fake():
+    assert True
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+# content of: tox.ini , put in same dir as setup.py
+[tox]
+envlist = py27,py36
+
+[testenv]
+deps=pytest
+commands=pytest --color=yes tests/{posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27,py36
+envlist = py26,py27,py36
 
 [testenv]
-deps=pytest
-commands=pytest --color=yes tests/{posargs}
+deps =
+  pytest
+  -rrequirements.txt
+commands =
+  python -m pytest --color=yes tests/{posargs}


### PR DESCRIPTION
Hi there!

I randomly came across your project and I'm liking it. Since I'm now defaulting to python 3, the first attempt to use `terminal_velocity` (nice name, btw) didn't work. I read issue #4, but I personally don't see any good reason to start a new repo for a python 3 version, so  I nerded out and decided to make changes and add the tools necessary to make your code python 2 and python 3 compatible, on a single code base.

In this branch I added the following:
  - Some very basic tests (these are incomplete, so you should probably add more). Tests are handled by [pytest](https://docs.pytest.org/en/latest/) and [tox](https://tox.readthedocs.io/en/latest/)
  - Ability to test for different python versions (currently 2.6, 2.7, 3.3, 3.4, 3.5 & 3.6)
  - Continuous integration via Travis, to run tests for all version automatically when pushing to github

In fact, I did some very minor changes now it seems to work (at least `notebook.py`) on python 2.7 and 3.3, 3.4, 3.5 and 3.6 (as you can see [here](https://travis-ci.org/jorgehatccrma/terminal_velocity). It is interesting that one of the tests I wrote fails on python 2.6 (that part should be using the exact same code in your master branch). **IMPORTANT** I didn't add any tests for `urwid_ui.py`, so you might want to do that.

To make it work in python 3 and made some minor modifications. The biggest hack I did was to completely bypass `notebook.unicode_or_bust` for python >= 3.0. This may or may not be what you want (I'll leave that to you). As I said, I only added very very basic tests, so more tests would be helpful. If you really intend to use CI, you should add more tests, especially around text encoding/decoding, which is the major difference between python 2 and 3. 